### PR TITLE
Addition of gitattributes for classification of *.t files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.t linguist-language=Perl


### PR DESCRIPTION
Added linguist attribute classifying *.t files as Perl instead of Raku, I have no issues in Raku, but in this context it is not correct